### PR TITLE
PIEN-7776

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- PIEN-7776: Secure case where no anchor links exist in content.
+
 ## [0.2.0] - 2022-10-03
 
 - PIEN-7627: Style fixes for extra paragraphs and line breaks inside Drupal content.

--- a/src/ImportObjectData.php
+++ b/src/ImportObjectData.php
@@ -175,16 +175,18 @@ class ImportObjectData {
 
         // The content may have <p> tags inside <a> tags which are messing the layout in WordPress,
         // so let's change those to <span> tags preserving the original HTML class.
-        $nodes
-            ->filter( 'a' )
-            ->children( 'p' )
-            ->each( function ( Crawler $node ) use ( $doc ) {
-                foreach ( $node as $p ) {
-                    $span = $doc->createElement( 'span', trim( $p->textContent ) );
-                    $span->setAttribute( 'class', $p->getAttribute( 'class' ) );
-                    $p->parentNode->replaceChild( $span, $p );
-                }
-            } );
+        $anchor_links = $nodes->filter( 'a' );
+        if ( $anchor_links->count() ) {
+            $anchor_links
+                ->children( 'p' )
+                ->each( function ( Crawler $node ) use ( $doc ) {
+                    foreach ( $node as $p ) {
+                        $span = $doc->createElement( 'span', trim( $p->textContent ) );
+                        $span->setAttribute( 'class', $p->getAttribute( 'class' ) );
+                        $p->parentNode->replaceChild( $span, $p );
+                    }
+                } );
+        }
 
         // Modify relative URLs.
         $nodes->filter( 'a, img, source, iframe' )->each( function ( Crawler $node ) use ( &$replace_map, $url_prefix ) {


### PR DESCRIPTION
Secure case where no anchor links exist in content. DOMCrawler throws an error if the node list passed to `children()` is empty, so we need to check that before calling `children()`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
