### PR TITLE
TMS-1017: Add news image alt-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- TMS-1017: Add news image alt-text
+
 ## [0.3.0] - 2022-04-11
 
 - PIEN-8157: PHP 8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+## [0.3.1] - 2022-03-18
+
 - TMS-1017: Add news image alt-text
 
 ## [0.3.0] - 2022-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
-## [0.3.1] - 2022-03-18
+## [0.3.1] - 2024-03-18
 
 - TMS-1017: Add news image alt-text
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: TMS News Importer
  * Plugin URI: https://github.com/devgeniem/tms-plugin-news-importer
  * Description: Import news from tampere.fi api.
- * Version: 0.3.0
+ * Version: 0.3.1
  * Requires PHP: 8.1
  * Author: Geniem Oy
  * Author URI: https://geniem.com

--- a/src/ImportObjectData.php
+++ b/src/ImportObjectData.php
@@ -107,6 +107,17 @@ class ImportObjectData {
     }
 
     /**
+     * Get image alternative text.
+     *
+     * @return string
+     */
+    public function get_image_alt() {
+        $image = $this->object_data->field_main_image->field_media_image ?: null;
+
+        return empty( $image ) ? '' : $image->meta->alt;
+    }
+
+    /**
      * Get target sites.
      *
      * @return array

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -210,6 +210,10 @@ final class Importer {
                     'value' => $import_object->get_image(),
                 ],
                 [
+                    'key'   => 'image_alt',
+                    'value' => $import_object->get_image_alt(),
+                ],
+                [
                     'key'   => 'writing_credits',
                     'value' => $import_object->get_writing_credits(),
                 ],
@@ -236,6 +240,7 @@ final class Importer {
         $target_site       = unserialize( get_post_meta( $id, 'wp_site_id', true ) );
         $drupal_post_id    = get_post_meta( $id, 'drupal_post_id', true );
         $image_url         = get_post_meta( $id, 'image_url', true );
+        $image_alt         = get_post_meta( $id, 'image_alt', true );
         $post_lang         = pll_get_post_language( $id );
         $writing_credits   = get_post_meta( $id, 'writing_credits', true );
         $image_credits     = get_post_meta( $id, 'image_credits', true );
@@ -267,6 +272,7 @@ final class Importer {
                     'drupal_post_id'  => $drupal_post_id,
                     'wp_site_id'      => $site,
                     'image_url'       => $image_url,
+                    'image_alt'       => $image_alt,
                     'writing_credits' => $writing_credits,
                     'image_credits'   => $image_credits,
                 ],


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1017 Drupalista tulevan uutisen pääkuvapaikan kuvan alt-teksti puuttuu
Task: https://hiondigital.atlassian.net/browse/TMS-1017

## Description
Fetch news image alternative text and add it to single news data

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
