### PR TITLE
TMS-1018: Remove margin from paragraph-tags around images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- TMS-1018: Remove margin from paragraph-tags around images
+
 ## [0.3.0] - 2022-04-11
 
 - PIEN-8157: PHP 8.1

--- a/assets/styles/exove-styles/_content.scss
+++ b/assets/styles/exove-styles/_content.scss
@@ -8,6 +8,10 @@
 
     .paragraph {
         position: relative;
+
+        &--type-image p {
+            margin: 0;
+        }
     }
 
     .anchor-link {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1018 Drupalista tulevan uutisen sisältöosan kuvapaikan yhteydessä turhia linkkinuoli-ikoneja ++kuvatekstin asemoinnista
Task: https://hiondigital.atlassian.net/browse/TMS-1018

## Description
Remove margin from paragraph-tags around images
