### PR TITLE
TMS-1063: Change post_date from 'created' to 'published_at'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- TMS-1063: Change post_date from 'created' to 'published_at'
+
 ## [0.3.1] - 2024-03-18
 
 - TMS-1017: Add news image alt-text

--- a/src/ImportObjectData.php
+++ b/src/ImportObjectData.php
@@ -58,6 +58,15 @@ class ImportObjectData {
     }
 
     /**
+     * Get published at time.
+     *
+     * @return string
+     */
+    public function get_published_time() {
+        return $this->object_data->published_at ?: '';
+    }
+
+    /**
      * Get created time.
      *
      * @return string

--- a/src/Importer.php
+++ b/src/Importer.php
@@ -162,7 +162,7 @@ final class Importer {
      * @return PostImportable
      */
     public function create_importable_object( object $import_object ) : PostImportable {
-        $post_date     = $import_object->get_created_time();
+        $post_date     = $import_object->get_published_time();
         $post_date_gmt = ( new \DateTime( $post_date ) )->format( 'Y-m-d H:i:s' );
 
         $post_modified_date     = $import_object->get_changed_time();


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1063 Drupalista tuleva uutinen näyttää luontiaikaa eikä julkaisuaikaansa
Task: https://hiondigital.atlassian.net/browse/TMS-1063

## Description
Change imported articles post date from 'created' to 'published_at' data

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
